### PR TITLE
docs: add badges area to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # PHPDoc parser TypeScript version
 
+<!-- Badges area start -->
+
+[![made by RightCapital](https://img.shields.io/badge/made_by-RightCapital-5070e6)](https://rightcapital.com)
+![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/RightCapitalHQ/phpdoc-parser/ci.yaml)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+[![RightCapital frontend style guide](https://img.shields.io/badge/code_style-RightCapital-5c4c64?labelColor=f0ede8)](https://github.com/RightCapitalHQ/frontend-style-guide)
+
+<!-- Badges area end -->
+
 Next-gen PHPDoc parser with support for intersection types and generics(TypeScript version)
 
 ## What's that

--- a/change/@rightcapital-phpdoc-parser-6a61b606-aa5e-40fb-8acf-8dae2ce999e0.json
+++ b/change/@rightcapital-phpdoc-parser-6a61b606-aa5e-40fb-8acf-8dae2ce999e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: add badges area to README file",
+  "packageName": "@rightcapital/phpdoc-parser",
+  "email": "i@rainx.cc",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
### Some badges to be added to README:

1. RightCapital open source badge: ![made by RightCapital](https://img.shields.io/badge/made_by-RightCapital-5070e6?link=https%3A%2F%2Frightcapital.com)
3. CI workflow status(This would not work correctly until the repo be public) :  ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/RightCapitalHQ/phpdoc-parser/ci.yaml)
4. Conventional Commits: [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
5. RightCapital frontend style badge(?):  to be created(?) ( @frantic1048 )
