### PR TITLE
fix: update renovate post-upgrade command to match allowed list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,10 @@
   "automergeType": "pr",
   "platformAutomerge": true,
   "prCreation": "immediate",
-  "allowedPostUpgradeCommands": ["^git", "^npx"],
   "postUpgradeTasks": {
     "commands": [
       "git add --all",
-      "npx beachball@latest change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'",
+      "npx beachball change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'",
       "git reset"
     ],
     "executionMode": "branch",
@@ -23,7 +22,7 @@
     "postUpgradeTasks": {
       "commands": [
         "git add --all",
-        "npx beachball@latest change --nofetch --no-commit --type none --message '{{{commitMessage}}}'",
+        "npx beachball change --nofetch --no-commit --type none --message '{{{commitMessage}}}'",
         "git reset"
       ],
       "executionMode": "branch",
@@ -58,7 +57,7 @@
       "postUpgradeTasks": {
         "commands": [
           "git add --all",
-          "npx beachball@latest change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
+          "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
           "git reset"
         ],
         "fileFilters": ["change/*.json"],


### PR DESCRIPTION
## Description:

This PR is aimed at fixing the mismatch observed between Renovate's `allowedPostUpgradeCommands` and the actual `postUpgradeTasks` commands in `renovate.json` file.

The issue arises from the discrepancy between the expected `allowedPostUpgradeCommands`:

```json
"allowedPostUpgradeCommands": [
  "^git add --all$",
  "^git reset$",
  "^npx beachball change( --no-fetch)? --no-commit --type (patch|none) --message '{{{commitMessage}}}'$", <<<
  "^pwd$"
]
```

And our `postUpgradeTasks`:

```json
"commands": [
  "git add --all",
  "npx beachball@latest change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'", <<<
  "git reset"
]
```

Noticeably, the `npx beachball@latest change...$` command does not correctly match with `^npx beachball change...$"` from the `allowedPostUpgradeCommands`. 

Therefore, the solution presented in this PR entails removing the `@latest` tag from the `npx beachball` command in our `postUpgradeTasks` configuration. This change will ensure that the executed command aligns with the `allowedPostUpgradeCommands` configuration, resolving the issue.


Additionally, as Renovate App does not use the `allowedPostUpgradeCommands` field configured at the repository level, it has been removed in this PR.
  - https://github.com/renovatebot/renovate/discussions/16555
  - https://github.com/renovatebot/renovate/discussions/17906