### PR TITLE
chore: cleanup unused `start` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "build": "pnpm run clean && tsc --project ./tsconfig.build.json",
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky install",
-    "start": "ts-node src/index.ts",
     "eslint": "eslint --report-unused-disable-directives 'src/**/*.ts*'",
     "eslint:fix": "eslint --report-unused-disable-directives --fix 'src/**/*.ts*'",
     "test": "jest"


### PR DESCRIPTION
1. remove unused command `npm start` cause it is doing nothing.

## Pull Request type


Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

it has a `start` npm script, it would not do anything.

## What is the new behavior?

no `start` npm script


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

