### PR TITLE
fix: modify generic type transpiling

### DIFF
--- a/change/@rightcapital-phpdoc-parser-c3a9dd19-9660-47d4-81f7-cf7e3c9def0d.json
+++ b/change/@rightcapital-phpdoc-parser-c3a9dd19-9660-47d4-81f7-cf7e3c9def0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: modify generic type parsing",
+  "packageName": "@rightcapital/phpdoc-parser",
+  "email": "yilunsun11@yeah.net",
+  "dependentChangeType": "patch"
+}

--- a/src/phpdoc-parser/transpiler/php-doc-to-typescript-type-transpiler.ts
+++ b/src/phpdoc-parser/transpiler/php-doc-to-typescript-type-transpiler.ts
@@ -95,8 +95,22 @@ export class PhpDocTypeNodeToTypescriptTypeNodeTranspiler {
             this.transpile(sourceTypeNode.genericTypes[0]),
           );
         }
+
         if (sourceTypeNode.genericTypes.length === 2) {
           // Record<KeyType, ValueType>
+
+          if (
+            sourceTypeNode.genericTypes[0].isIdentifierTypeNode() &&
+            ['int', 'integer', 'float', 'double'].includes(
+              sourceTypeNode.genericTypes[0].name,
+            )
+          ) {
+            // turn into regular Array like Type[]
+            return factory.createArrayTypeNode(
+              this.transpile(sourceTypeNode.genericTypes[1]),
+            );
+          }
+
           return factory.createTypeReferenceNode(
             factory.createIdentifier('Record'),
             [

--- a/tests/transpiler/transpiler.test.ts
+++ b/tests/transpiler/transpiler.test.ts
@@ -62,6 +62,7 @@ describe('TranspilerTest', () => {
   const commentText = `/**
     * @property-read  array|null  $person
     * @property       int         $id
+    * @property-read  \\Illuminate\\Database\\Eloquent\\Collection<int, int>  $ids
     */`;
 
   // Parse the PHPDoc comment text to get node structures.
@@ -71,6 +72,7 @@ describe('TranspilerTest', () => {
   const transpiledTypeDefinitionTestCases = [
     'person: any | null;',
     'id: number;',
+    'ids: number[];',
   ];
 
   transpiledCommentNodes.forEach((transpiledCommentNode, index) => {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

``` 
/**
 * @property-read  array<int, int>  $ids
 */
```
For the parsing of the generic type like this, we previously would transpile it as

`ids: Record<number, number>`

However, if the first argument of a generic type is a number, transpiling it as an array is a better behavior.

The conversion to `number[]` significantly enhances code readability by clearly indicating an array of numbers, making the intent more intuitive than `Record<number, number>`. It also aligns with common TypeScript/JavaScript practices by taking full advantage of built-in array functionalities for more straightforward manipulation and iteration.


## What is the new behavior?

`ids:  number[]`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
