### PR TITLE
feat(transpiler): enhance transpiler with importName and typeIdentifiers

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -2,3 +2,4 @@
 Ue = "Ue"
 ND = "ND"
 ba = "ba"
+ede = "ede"

--- a/change/@rightcapital-phpdoc-parser-f62100bd-d0db-46d7-9eb1-b19a88d2d5f5.json
+++ b/change/@rightcapital-phpdoc-parser-f62100bd-d0db-46d7-9eb1-b19a88d2d5f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enhance PhpDocTypeNodeToTypescriptTypeNodeTranspiler with importName and typeIdentifiers",
+  "packageName": "@rightcapital/phpdoc-parser",
+  "email": "yilunsun11@yeah.net",
+  "dependentChangeType": "patch"
+}

--- a/tests/transpiler/transpiler.test.ts
+++ b/tests/transpiler/transpiler.test.ts
@@ -18,7 +18,8 @@ class ExtendedTranspiler extends PhpDocTypeNodeToTypescriptTypeNodeTranspiler {
       (nodeParts: string[]) =>
         resolver.call(this, nodeParts) as {
           path: string;
-          name: string;
+          importName: string;
+          typeIdentifiers: string[];
           isTypeOnly: boolean;
         },
     );
@@ -49,10 +50,13 @@ const getPropertyTagValueNodesFromComment = (commentText: string) => {
 const nameNodePathResolver: NameNodePathResolver<ExtendedTranspiler> =
   // eslint-disable-next-line func-names
   function (this: ExtendedTranspiler, nodeParts: string[]) {
+    const lastPart = nodeParts.at(-1);
+
     return {
-      name: nodeParts.at(-1),
       path: '',
       isTypeOnly: false,
+      importName: lastPart,
+      typeIdentifiers: [lastPart],
     };
   };
 


### PR DESCRIPTION
- Added importName and typeIdentifiers to the nameNodePathResolver return type.
- Updated logic to handle external types and generate import statements accordingly.
- Improved type reference creation to support qualified names for multiple identifiers.

<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
